### PR TITLE
Add cluster network display for VMs

### DIFF
--- a/all.html
+++ b/all.html
@@ -160,6 +160,7 @@
     <div id="panel">
         <h1 data-readonly-key="QjOgLD7b2yFA3WWjzO1ny40UM7kxk2lJ">Services</h1>
         <h1 data-readonly-key="dpv-exDWE6qf3f50apUPF9r-0xbmNBoF">Bare-Metal Network Connections</h1>
+        <h1 data-readonly-key="8PYbVa7WY69q6FQUSeZB1Ihu8ue2c8C2">VM Cluster Network</h1>
     </div>
 
     <div class="check-template">


### PR DESCRIPTION
VMs in Proxmox will now have their cluster network checks displayed on
the "all" page in the status website.

- [x] The API used was a read-only API key.

What the `/all` page now looks like (tested on localhost):
![image](https://user-images.githubusercontent.com/22606608/129830782-97429555-3700-4e05-8028-5f5e055975f2.png)

These changes are a result of the additions in https://git.uwaterloo.ca/WATonomous/ansible-config/-/merge_requests/158.