### PR TITLE
Use mutex when deploying to gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex
+        uses: ben-z/gh-action-mutex@v1.0-alpha-1
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex
+        uses: ben-z/gh-action-mutex@v1.0-alpha-1
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-2
+        uses: ben-z/gh-action-mutex@v1.0-alpha-3
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-2
+        uses: ben-z/gh-action-mutex@v1.0-alpha-3
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,6 @@ on:
 
   workflow_dispatch:
 
-concurrency: build_and_deploy_concurrency_group
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main'
     needs: [build]
+    concurrency: deploy_prod_concurrency_group
     steps:
       - uses: actions/checkout@v2
 
@@ -54,6 +53,12 @@ jobs:
         with:
           name: build-output
           path: ./out
+
+      - name: Set up mutex
+        uses: ben-z/gh-action-mutex
+        with:
+          branch: mutex-gh-pages
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.5
@@ -74,6 +79,12 @@ jobs:
         with:
           name: build-output
           path: ./out
+
+      - name: Set up mutex
+        uses: ben-z/gh-action-mutex
+        with:
+          branch: mutex-gh-pages
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Preview Environment
         uses: JamesIves/github-pages-deploy-action@v4.2.5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-1
+        uses: ben-z/gh-action-mutex@v1.0-alpha-2
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
           path: ./out
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-1
+        uses: ben-z/gh-action-mutex@v1.0-alpha-2
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -1,4 +1,4 @@
-name: Clean up after PRs are closed or merged
+name: Clean up after closing/merging a PR
 
 on:
   pull_request:

--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -18,7 +18,7 @@ jobs:
           echo '${{ toJSON(github.event.pull_request) }}'
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-2
+        uses: ben-z/gh-action-mutex@v1.0-alpha-3
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -18,7 +18,7 @@ jobs:
           echo '${{ toJSON(github.event.pull_request) }}'
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-1
+        uses: ben-z/gh-action-mutex@v1.0-alpha-2
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -18,7 +18,7 @@ jobs:
           echo '${{ toJSON(github.event.pull_request) }}'
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex
+        uses: ben-z/gh-action-mutex@v1.0-alpha-1
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-concurrency: build_and_deploy_concurrency_group
-
 jobs:
   delete_preview:
     runs-on: ubuntu-latest
@@ -18,6 +16,12 @@ jobs:
           echo '${{ toJSON(github.event_name) }}'
           echo "===== github.event.pull_request"
           echo '${{ toJSON(github.event.pull_request) }}'
+
+      - name: Set up mutex
+        uses: ben-z/gh-action-mutex
+        with:
+          branch: mutex-gh-pages
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Resolves https://github.com/WATonomous/status/issues/35

Uses https://github.com/marketplace/actions/mutex-action to limit concurrency for deployments to 1 while not cancelling old jobs when there are more than 2 jobs.