### PR TITLE
Specify write permissions for mutex lock explicitly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [build]
+    # Specify write permissions explicitly to make dependabot PRs happy:
+    # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-940182533
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 
@@ -73,10 +77,6 @@ jobs:
 
       - name: Set up mutex
         uses: ben-z/gh-action-mutex@v1.0-alpha-3
-        # Specify write permissions explicitly to make dependabot PRs happy:
-        # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-940182533
-        permissions:
-          contents: write
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
     needs: [build]
     # Specify write permissions explicitly to make dependabot PRs happy:
     # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-940182533
+    # This is okay in this job because we don't execute any external code (e.g. npm export).
     permissions:
       contents: write
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
     # This is okay in this job because we don't execute any external code (e.g. npm export).
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,10 @@ jobs:
 
       - name: Set up mutex
         uses: ben-z/gh-action-mutex@v1.0-alpha-3
+        # Specify write permissions explicitly to make dependabot PRs happy:
+        # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-940182533
+        permissions:
+          contents: write
         with:
           branch: mutex-gh-pages
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflows on Dependabot commits are run with read permissions only [1](https://github.com/dependabot/dependabot-core/issues/3253) [2](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).

There's a workaround to explicitly state permissions per job [1](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-940182533) [2](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/). This PR applies that.