### PR TITLE
Remove debug msgs from .github/workflows/pr-clean-up.yml

### DIFF
--- a/.github/workflows/pr-clean-up.yml
+++ b/.github/workflows/pr-clean-up.yml
@@ -8,15 +8,6 @@ jobs:
   delete_preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Debug
-        run: |
-          echo "===== github.ref_name"
-          echo '${{ toJSON(github.ref_name) }}'
-          echo "===== github.event_name"
-          echo '${{ toJSON(github.event_name) }}'
-          echo "===== github.event.pull_request"
-          echo '${{ toJSON(github.event.pull_request) }}'
-
       - name: Set up mutex
         uses: ben-z/gh-action-mutex@v1.0-alpha-3
         with:


### PR DESCRIPTION
Sometimes actions error out due to unknown reasons: https://github.com/WATonomous/status/actions/runs/2050099239

I think there's a bug in `toJSON`. Won't look into it too much. Will just work around it by removing the debug comments.

If anyone in the future sees this, it is fully reproducible on all dependabot PRs. Not sure why:

https://github.com/WATonomous/status/actions/runs/2046741802
https://github.com/WATonomous/status/actions/runs/2046741771
https://github.com/WATonomous/status/actions/runs/2046741640
https://github.com/WATonomous/status/actions/runs/2046741535